### PR TITLE
修改muduo库冗余代码EventLoop和Poller文件，其原因是poller子类已经使用map保存了Channel

### DIFF
--- a/src/EPollPoller.cc
+++ b/src/EPollPoller.cc
@@ -129,7 +129,8 @@ void EPollPoller::update(int operation, Channel *channel)
     int fd = channel->fd();
 
     event.events = channel->events();
-    event.data.fd = fd;
+    //这里是联合体所以data.fd写了没有意义会被data.ptr覆盖
+    // event.data.fd = fd;
     event.data.ptr = channel;
 
     if (::epoll_ctl(epollfd_, operation, fd, &event) < 0)

--- a/src/EventLoop.cc
+++ b/src/EventLoop.cc
@@ -186,10 +186,10 @@ void EventLoop::removeChannel(Channel *channel)
     poller_->removeChannel(channel);
 }
 
-bool EventLoop::hasChannel(Channel *channel)
-{
-    return poller_->hasChannel(channel);
-}
+// bool EventLoop::hasChannel(Channel *channel)
+// {
+//     return poller_->hasChannel(channel);
+// }
 
 void EventLoop::doPendingFunctors()
 {

--- a/src/Poller.cc
+++ b/src/Poller.cc
@@ -6,8 +6,8 @@ Poller::Poller(EventLoop *loop)
 {
 }
 
-bool Poller::hasChannel(Channel *channel) const
-{
-    auto it = channels_.find(channel->fd());
-    return it != channels_.end() && it->second == channel;
-}
+// bool Poller::hasChannel(Channel *channel) const
+// {
+//     auto it = channels_.find(channel->fd());
+//     return it != channels_.end() && it->second == channel;
+// }


### PR DESCRIPTION
根据群里的反馈修改muduo库冗余的代码，其原因是在Poller的子类EpollPoller中将其使用map进行了Channel的保存。